### PR TITLE
fix: update padding and margin for elements as per material design

### DIFF
--- a/css/components/snackbar.css
+++ b/css/components/snackbar.css
@@ -1,6 +1,7 @@
 .snackbar {
     z-index: 100;
-    max-width: 400px;
+    min-width: 288px;
+    max-width: 568px;
     height: 3rem;
    
     display: flex;
@@ -16,8 +17,8 @@
     font-size: var(--size-9);
     
     color: var(--white);
-    border-radius: var(--radius-large);
-    background-color: var(--grey-lighter);
+    border-radius: var(--radius-small);
+    background-color: #323232;
 }
 
 .snackbar .icon {
@@ -47,6 +48,7 @@
     border: 0;
     flex-grow: 1;
     margin-left: auto;
+    text-transform: uppercase;
 }
 
 .snackbar .btn .icon {

--- a/css/components/snackbar.css
+++ b/css/components/snackbar.css
@@ -1,18 +1,19 @@
 .snackbar {
     z-index: 100;
     max-width: 400px;
+    height: 3rem;
    
     display: flex;
     justify-content: flex-start;
     align-items: center;
     line-height: 1.5;
-    padding: var(--size-4) var(--size-9);  
+    padding: var(--size-8) var(--size-11);  
     
     position: fixed;
     bottom: var(--size-9);
     left: 50%;
     transform: translateX(-50%);
-    font-size: var(--size-10);
+    font-size: var(--size-9);
     
     color: var(--white);
     border-radius: var(--radius-large);
@@ -34,7 +35,7 @@
 
 .snackbar .is-msg {
     font-weight: 500;
-    margin-right: var(--size-7);
+    margin-right: 3rem;
 }
 
 /* ---- Right side buttons ---- */


### PR DESCRIPTION
Update padding, margin, width, color as per specs mentioned in https://material.io/archive/guidelines/components/snackbars-toasts.html#snackbars-toasts-specs

Preview:
<img width="1665" alt="Screenshot 2022-02-08 at 10 24 58 PM" src="https://user-images.githubusercontent.com/67374176/153036472-e0aa8fad-bc63-47e0-a941-7b5b37f96c02.png">

